### PR TITLE
Apply prettier to all Ruby source

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "extends": [
     "plugin:@prettier/plugin-ruby"
-  ]
+  ],
+  "rubyPlugins": "plugin/single_quotes"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update -qq \
     libmariadb-dev \
     build-essential \
     git \
-    shared-mime-info
+    shared-mime-info \
+    nodejs
 
 ARG BUNDLER_VERSION=2.1.4
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cruft_tracker (0.1.4)
+    cruft_tracker (0.2.0)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 
@@ -93,6 +93,9 @@ GEM
       railties (>= 3.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    haml (5.2.2)
+      temple (>= 0.8.0)
+      tilt
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     loofah (2.16.0)
@@ -111,6 +114,11 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    prettier (3.1.2)
+      syntax_tree (>= 2.3.1)
+      syntax_tree-haml (>= 1.1.0)
+      syntax_tree-rbs (>= 0.2.0)
+    prettier_print (0.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -149,6 +157,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (10.5.0)
+    rbs (2.6.0)
     regexp_parser (2.3.0)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -199,7 +208,19 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    syntax_tree (3.0.0)
+      prettier_print
+    syntax_tree-haml (1.2.0)
+      haml (>= 5.2)
+      prettier_print
+      syntax_tree (>= 2.0.1)
+    syntax_tree-rbs (0.4.0)
+      prettier_print
+      rbs
+      syntax_tree (>= 2.0.1)
+    temple (0.8.2)
     thor (1.2.1)
+    tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -218,6 +239,7 @@ DEPENDENCIES
   database_cleaner (~> 2.0.1)
   generator_spec (~> 0.9.4)
   mysql2 (~> 0.5.3)
+  prettier
   pry-byebug (~> 3.9)
   rails (>= 5.2)
   rake (~> 10.0)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # CruftTracker
 
-Have you ever asked yourself, "Is this method even being used?!" Or, "What the heck is this method receiving?" Or, perhaps, "is this partial being used?" Does your application use Rails? If the answers
+Have you ever asked yourself, "Is this method even being used?!" Or, "What the heck is this method receiving?" Does your application use Rails? If the answers
 these questions are yes, this gem may be of use to you!
 
-Large applications can accrue cruft; old methods that might once have been important, but are now unused, or code that is difficult to understand, but dangerous to refactor. The same is can be true for views and partials in Rails applications. Unfortunately,
+Large applications can accrue cruft; old methods that might once have been important, but are now unused or code that is difficult to understand, but dangerous to refactor. Unfortunately,
 software is _complex_ and sometimes it's unclear what's really going on. This adds maintenance burdens, headaches, and uncertainty.
 
-This gem aims to give you some tools to make it easier to know what (and how) your code is being used (or not).
+This gem aims to give you a couple tools to make it easier to know what (and how) your code is being used (or not).
 
 CruftTracker supports Rails versions 5.2 to 6.1 at this time. As of now the gem only supports MySQL, but contributions for Postgres or other DBMS would be welcome.
 
@@ -37,16 +37,6 @@ After that, you can run migrations as you normally would. If you've previously i
 
 ## Usage
 
-### Rails Initializer
-
-You should configure CruftTracker by creating an initializer in your Rails application's `config/initializers` directory named `cruft_tracker.rb`. The structure of the initializer is:
-
-```ruby
-CruftTracker.init do
-  # your configuration.... (more on this below)
-end
-```
-
 ### Tracking method invocations
 
 CruftTracker is pretty simple. Let's say you have a class (or module) like this...
@@ -59,17 +49,19 @@ class SomeOldClass
 end
 ```
 
-You're unsure if the `some_old_method` method is actually being used. All you need to do is add an instance of the  `is_this_method_used? ` to the CruftTracker initializer. This method requires you to pass the class constant and a symbol to identify the name of the method to track. For example:
+You're unsure if the `some_old_method` method is actually being used. All you need to do is use `CruftTracker.is_this_method_used?`. This method requires you to pass `self` and a symbol to identify the name of the method to track. For example:
 
 ```ruby
-# config/initializers/cruft_tracker.rb
+class SomeOldClass
+  def some_old_method
+    # do things
+  end
 
-CruftTracker.init do
-  is_this_method_used? SomeOldClass, :some_old_method
+  CruftTracker.is_this_method_used? self, :some_old_method
 end
 ```
 
-What do you get out of this? Well, as soon as Rails runs the CruftTracker initializer, CruftTracker will create a new record
+What do you get out of this? Well, as soon as Ruby loads the `SomeOldClass` class, CruftTracker will create a new record
 in the `cruft_tracker_methods` table that looks like this:
 
 
@@ -93,28 +85,30 @@ The fields are:
 - `updated_at` - The last time this record was updated. IE: the last time the tracked method was invoked.
 
 Looking at this, we can see that the `some_old_method` method has never been invoked. This is nice because it means that
-you can track uses of methods without changing their behavior (or editing their class) and also know when a method has _not_ been used. A similar record is created for every method you track
-with `is_this_method_used?`.
+you can track uses of methods without changing their behavior and also know when a method has _not_ been used. A similar record is created for every method you annotate
+with `CruftTracker.is_this_method_used?`.
 
-You should always have records for potentially crufty
+Assuming your production application eagerly loads classes, you should always have records for potentially crufty
 methods, even if the class itself is never explicitly used.
 
-So, having configured the method to be tracked, you can check this table after a while. If you see that there have been zero invocations,
+So, having annotated the method, you can check this table after a while. If you see that there have been zero invocations,
 you have a reasonably good hint that the method may not actually be used. Of course, you should consider that there are
 some processes that are not run frequently at all, so this gem isn't a panacea. **Think before you delete!**
 
-`is_this_method_used?` can be used to track any kind of method (except `initialize`) with any visibility. This includes class and module methods (`self.`), private class methods, eigenclass methods, as well as public, private, and protected instance methods.
+`CruftTracker.is_this_method_used?` can be used to track any kind of method (except `initialize`) with any visibility. This includes class and module methods (`self.`), private class methods, eigenclass methods, as well as public, private, and protected instance methods.
 
 ### Comments
 
 Since you may have to track a method for a while, it might be helpful to have a reminder as to _why_ you're tracking it in the first place. This can be recorded by providing an optional `comments:` named argument. For example:
 
 ```ruby
-# config/initializers/cruft_tracker.rb
+class SomeOldClass
+  def some_old_method
+    # do things
+  end
 
-CruftTracker.init do
-  is_this_method_used?
-    SomeOldClass,
+  CruftTracker.is_this_method_used?
+    self,
     :some_old_method,
     comment: "I suspect this method is being called via metaprogramming."
 end
@@ -123,11 +117,13 @@ end
 `comment:` can be anything that can be serialized to JSON. For example:
 
 ```ruby
-# config/initializers/cruft_tracker.rb
+class SomeOldClass
+  def some_old_method
+    # do things
+  end
 
-CruftTracker.init do
-  is_this_method_used?
-    SomeOldClass,
+  CruftTracker.is_this_method_used?
+    self,
     :some_old_method,
     comment: {
       creator: "Doug Hughes",
@@ -143,7 +139,7 @@ The comment is serialized to json and stored in the `comments` field of the `Cru
 By default, CruftTracker will record unique backtraces for each invocation of a tracked method. This data is stored in the `cruft_tracker_backtraces` table and is accessible via the `CruftTracker::Method`'s `backtraces` association. The `cruft_tracker_backtraces` table has the following columns:
 
 - `id` - Ye olde primary key.
-- `traceable_type` - The type for the polymorphic `traceable` association. Future versions of CruftTracker may track data in addition to method invocations. (Note: This was originally made polymorphic to support view tracking. Since view tracking can't use the backtraces feature, the polymorphism is vestigial and may be removed in the future.)
+- `traceable_type` - The type for the polymorphic `traceable` association. Future versions of CruftTracker may track data in addition to method invocations.
 - `traceable_id` - The ID of the polymorphic `traceable` association. EG: the `CruftTracker::Method` the backtrace is recorded for.
 - `trace_hash` - Traces are stored as JSON. This column is an MD5 hash of the trace that is indexed to make it easier / faster to know if we've seen a particular trace before.
 - `trace` - The trace data, stored as a JSON array of hashes.
@@ -151,7 +147,7 @@ By default, CruftTracker will record unique backtraces for each invocation of a 
 - `created_at` - The first time we saw a particular backtrace.
 - `updated_at` - The most recent time we saw a particular backtrace.
 
-Backtraces can be referenced to figure out exactly where a tracked method is being used. It also implicitly tells you other code that is definitely being used. Do note that as code changes, these backtrace records are not updated. So, if a backtrace says the tracked method was invoked from line 123 of some file, if that file is edited, the line numbers may no longer match and would be recorded as a new backtrace.
+Backtraces can be referenced to figure out exactly where a tracked method is being used. It also implicitly tells you other code that is definitely being used. Do note that as code changes, these record backtraces are not updated. So, if a backtrace says the tracked method was invoked from line 123 of some file, if that file is edited, the line numbers may no longer match. Also, this would be record as a new backtrace.
 
 Future versions of CruftTracker may provide a UI for exploring backtraces.
 
@@ -189,36 +185,42 @@ Now, I ask you a few questions:
 2. What options does `do_something_via_metaprogramming` receive? Are they always the same options?
 3. What classes and methods does `do_something_via_metaprogramming` invoke via metaprogramming?
 
-The answers: _Who the heck knows?!_ 🤷
+The answer: _Who the heck knows?!_ 🤷
 
 So, let's start collecting some data about these arguments. We can do this with the `track_arguments:` named argument on `is_this_method_used?`. This argument takes a proc that receives an `args` array as an argument. Whatever the proc returns is serialized to JSON and stored in the `cruft_tracker_arguments` table.
 
 The naive approach to tracking arguments would be to use something like this:
 
 ```ruby
-# config/initializers/cruft_tracker.rb
+class SomeClass
+  def do_something_via_metaprogramming(options)
+    options[:target_class].constantize.send(options[:method], options[:modifiers])
+    YetAnotherClass.do_something_else(options)
+  end
 
-CruftTracker.init do
-  is_this_method_used?
-    SomeClass,
+  CruftTracker.is_this_method_used?
+    self,
     :do_something_via_metaprogramming,
     track_arguments: -> (args) { args }
 end
 ```
 
-This will track all of the values of the options provided to the `do_something_via_metaprogramming` method. This could be a problem. Consider a case where the method is used a zillion times per day and where there's a plethora of complicated data being passed through the method via its `options` argument. It's possible that each set of arguments is different. This could result in one `potential_cruft_arguments` record per invocation of the tracked method. This may not be what you want to know... What you probably want to know in this case is:
+This will track all of the values of the options provided to the `do_something_via_metaprogramming` method. This could be a problem. Consider a case where the method is used a zillion times per day and where there's a plethora of complicated data being passed through the method via its `options` argument. It's possible that each set of arguments is different. This could result in one `potential_cruft_arguments` record per invocation of the tracked method. This is both probably not what. What you probably want to know in this case is:
 
 - What are the unique sets of keys in the `options` hash?
 - What classes and methods are we calling via metaprogramming?
 
-Instead, we could write a proc that looks like this:
+We could write a proc that looks like this:
 
 ```ruby
-# config/initializers/cruft_tracker.rb
+class SomeClass
+  def do_something_via_metaprogramming(options)
+    options[:target_class].constantize.send(options[:method], options[:modifiers])
+    YetAnotherClass.do_something_else(options)
+  end
 
-CruftTracker.init do
-  is_this_method_used?
-    SomeClass,
+  CruftTracker.is_this_method_used?
+    self,
     :do_something_via_metaprogramming,
     track_arguments: -> (args) do
       options = args.first
@@ -304,11 +306,9 @@ Arguments are tracked in the `cruft_tracker_arguments` table which has these col
 - `updated_at` - The most recent time we saw a particular set of arguments.
 
 
-### Tracking All Methods
+### Tracking Everything
 
-So, let's say you've got a class with a bunch of methods. You want to know if any of the methods are being used, and you just don't want to think very hard about it. That's where `are_any_of_these_methods_being_used?` comes to the rescue! Just add this to the CruftTracker initializer as shown below.
-
-Let's say this is your class:
+So, let's say you've got a class with a bunch of methods. You want to know if any of the methods are being used, and you just don't want to think very hard about it. That's where `CruftTracker.are_any_of_these_methods_being_used?` comes to the rescue! Just tack that onto the end of your class like this to track all method invocations:
 
 ```ruby
 class SomeClass
@@ -328,208 +328,18 @@ class SomeClass
   end
 
   # ... other methods ...
-end
-```
 
-Here's the configuration in the initializer:
-
-```ruby
-# config/initializers/cruft_tracker.rb
-
-CruftTracker.init do
-  are_any_of_these_methods_being_used? SomeClass
+  CruftTracker.are_any_of_these_methods_being_used? self
 end
 ```
 
 This will result in a `cruft_tracker_methods` record being created for each method in the `SomeClass` class. It will _not_ track methods that exist in the class' (or module's) ancestors. It's a quick and easy way to see what's being used. This method cannot be used to track arguments, though it does accept a `comments:` named argument.
 
-You may want to think twice about using this method, or using this method too widely as it may create more data than you expect. CruftTracker is lightweight, but too much of a good thing is still too much. Generally, you should favor tracking only what you are specifically interested in.
-
-### Tracking Views
-
-In additon to tracking methods, CruftTracker lets you track details about view rendering. Consider this scenario: You have a large legacy application with a ton views and partials. Over time your controllers have been changed and sometimes deleted. Perhaps a partial was once widely used, but isn't anymore. You might want to be able to easily tell if a given partial or view is being used. Once again, CruftTracker to the rescue!
-
-Let's say you have this view and you're just not sure it's being used anymore:
-
-```erb
-<!-- app/views/something/some_view.html.erb -->
-  
-<div>
-	<%- if @data.present? %>
-  	<strong>Woo hoo!</strong>
-  <% end %>
-</div>
-```
-
-You can track renders of this view by using `is_this_view_used?` in the CruftTracker initializer:
-
-```ruby
-# config/initializers/cruft_tracker.rb
-
-CruftTracker.init do
-  is_this_view_used? 'app/views/something/some_view.html.erb'
-end
-```
-
-Note that the path provided is from the application's root.
-
-As soon as Rails runs the CruftTracker initializer, CruftTracker will create a new record
-in the `cruft_tracker_views` table that looks like this:
-
-
-| id   | view                                   | renders | comment | deleted_at | created_at          | updated_at          |
-| ---- | -------------------------------------- | ------- | ------- | ---------- | ------------------- | ------------------- |
-| 1    | app/views/something/some_view.html.erb | 0       | null    | null       | 2022-01-21 14:07:48 | 2022-01-21 14:07:48 |
-
-This record is accessible using the `CruftTracker::View` model. EG: `CruftTracker::View.find(1)`
-
-The fields are:
-
-- `id` - Shockingly, this is the primary key.
-- `view` - This is the path to the view from the Rails application's root.
-- `renders` - The number of times the view has been rendered.
-- `comments` -  This is a JSON field containing extra data provided to the option `comments:` argument for the `is_this_view_used?` method.
-- `deleted_at` - When set, this indicates that the view is no longer being tracked.
-- `created_at` - The date/time we started tracking the view.
-- `updated_at` - The last time this record was updated. IE: the last time the tracked view was rendered.
-
-Looking at this, we can see that the `app/views/something/some_view.html.erb` view has never been rendered. This is nice because it means that
-you can track renders of views, but you can and also know when a view has _not_ been rendered. A similar record is created for every view you track
-with `is_this_view_used?` You should always have records for potentially crufty
-views, even if the view itself is never rendered.
-
-So, having configured the view to be tracked, you can check this table after a while. If you see that there have been zero renders,
-you have a reasonably good hint that the view may not actually be used. Of course, some things aren't used frequently. **Think before you delete!**
-
-`is_this_view_used?` can be used to track ordinary views as well as partials. While only tested with ERB templates, it should work with any other template engine, such as HAML. If you run into problems, please open a Github issue!
-
-### Tracking View Rendering Details
-
-Out of the box, you don't get a lot of information when tracking views. Basically, all you know is the number of times a view has been rendered. That's helpful, but not exactly amazing. Happily, CruftTracker provides a view helper that can be used to track a lot more information about view renders. The only downside is that it requires you to add a line of code to your templates. 
-
-Let's say you have this partial and you want to know not just if it's used, but _what uses it_.
-
-```erb
-<!-- app/views/shared/whatever.html.erb -->
-
-<div>I am a partial. Hear me roar.</div>
-
-<div><%= some_value %></div>
-```
-
-You'll still want to configure view tracking in the initializer:
-
-```ruby
-# config/initializers/cruft_tracker.rb
-
-CruftTracker.init do
-  is_this_view_used? 'app/views/shared/whatever.html.erb'
-end
-```
-
-However, to get additional details about renders of this partial, you can invoke the `record_cruft_tracker_view_render` helper into the view. It's recommended to add this on the first line of the view. EG:
-
-```erb
-<!-- app/views/shared/whatever.html.erb -->
-  
-<%- record_cruft_tracker_view_render %>
-
-<div>I am a partial. Hear me roar.</div>
-
-<div><%= some_value %></div>
-```
-
-When the view is actually rendered, CruftTracker will collect information about the render and store it in the `cruft_tracker_view_renders` table, like this:
-
-| id   | view_id | render_hash                      | controller     | endpoint     | route                  | render_stack | occurrences | created_at          | updated_at          |
-| ---- | ------- | -------------------------------- | -------------- | ------------ | ---------------------- | ------------ | ----------- | ------------------- | ------------------- |
-| 1    | 1       | 98cc3bd79cf6f3606c5afe3b9faf925b | SomeController | do_something | /foo/:id/bar(.:format) | [{...}]      | 1           | 2022-07-06 15:29:06 | 2022-07-06 15:29:06 |
-
-This record is represented by the `CruftTracker::ViewRender` model and can be loaded in the usual ways. You can also access it from a specific view record. EG: `CruftTracker::View.find(1).view_renders`, which will return an association of unique renders.
-
-There's a lot packed into that record. Let's disect it:
-
-* `id` - This is the primary key for the view render.
-
-* `view_id` - This is the id of the view that was rendered. 
-
-* `render_hash` - This is the MD5 hash of the combination of the `controller`, `endpoint`, `route`, `http_method`, and the JSON version of the `render_stack`. The combination of these fields must be unique so that we can count the number of occurrences. The `render_hash` is a shortcut used by CruftTracker to easily determine if the combination of these items is unique. Basically, it's for optimization purposes and you shouldn't worry about it. :wink:
-
-* `controller` - This is the class name for the controller that ultimately triggered rendering this view. Note that this controller is what kicked off the render, not necessarily what directly caused the view to be rendered. In the case of a partial, you could have a deeply nested set of renders. All the `controller` tells you is that a request to the controller ultimately caused the view to be rendered.
-
-* `endpoint` - This is the method within the controller that caused the view to be rendered. The same caveats apply as with `controller`.
-
-* `route` - This is the generic route that caused the view to be rendered. Note that this doesn't include the IDs, but the route's pattern for the IDs.
-
-* `http_method` - This is the HTTP method used to access the `endpoint`.
-
-* `render_stack` - This is an array that is _similar_ to a backtrace, but isn't actually a backtrace. To explain, if you call `render` in a controller, Rails doesn't actually render the view at that time. Instead, it ensues the view for rendering once the controller's method has finished executing. That means that if, while the view is rendering, you call invoke Ruby's `caller_locations`, you wouldn't see the controller that triggered the render. It was decided that this was generally pretty useless. Instead, what this field stores is the hierarchy of views / partials being rendered, but none of the other related code. It can provide a hint of how a deeply nested partial is rendered. Here's an example that shows a partial being rendered from a regular view: 
-
-  ```ruby
-  [
-    { "path": "/app/spec/dummy/app/views/shared/_whatever.html.erb", 
-      "label": "_app_views_shared__whatever_html_erb___436643032048620150_11500", 
-      "lineno": 1, 
-      "base_label": "_app_views_shared__whatever_html_erb___436643032048620150_11500" }, 
-    { "path": "/app/spec/dummy/app/views/main/show.html.erb", 
-      "label": "_app_views_main_show_html_erb__2350809826889573468_11260", 
-      "lineno": 6, 
-      "base_label": "_app_views_main_show_html_erb__2350809826889573468_11260"}
-  ]
-  ```
-
-* `occurrences` - This is the number of times that this particular set of details have been seen when rendering a particular view.
-
-* `created_at` - The date/time we first saw this controller, endpoint, route, etc render the view.
-
-* `updated_at` - The last time we first saw this controller, endpoint, route, etc render the view.
-
-### Tracking View Render Metadata
-
-Knowing what caused a view to render is all well and good, but sometimes you might want a little more insight. Similar to how you can track arguments on methods with CruftTracker, you can track metadata for views. This is simply an argument you provide to the `record_cruft_tracker_view_render`  method. For example:
-
-```erb
-<!-- app/views/shared/whatever.html.erb -->
-  
-<%- record_cruft_tracker_view_render(some_value) %>
-
-<div>I am a partial. Hear me roar.</div>
-
-<div><%= some_value %></div>
-```
-
-The metadata argument can be anything that is serializable to JSON. When you provide the argument, a record will be created or updated in the `cruft_tracker_render_metadata` table that looks like this:
-
-| id   | view_render_id | metadata_hash                    | metadata            | occurrences | created_at          | updated_at          |
-| ---- | -------------- | -------------------------------- | ------------------- | ----------- | ------------------- | ------------------- |
-| 1    | 1              | a434e71475ff330064970fdc9fb123fc | ...your metadata... | 1           | 2022-07-06 16:07:38 | 2022-07-06 16:07:38 |
-
-Let's break this down:
-
-* `id` - Ye olde primary key
-* `view_render_id` - This is the ID of the `CruftTracker::ViewRender` that this metadata is associated with.
-* `metadata_hash` - This is the hash of the `metadata` field so that we can easily create a unique index.
-* `occurrences` - The number of times that this exact metadata has been seen before.
-* `created_at` - The first time we saw this metadata.
-* `updated_at` - The most recent time we saw this metadata.
-
-`CruftTracker::RenderMetadata` can be accessed from a `CruftTracker::ViewRender` via its `render_metadata` association.
-
-A word of caution: don't track ever variable. Variables are, by definition, variable. Each time a view renders you could have a different value for a variable. Instead, this would be better used to track what variables are available. EG:
-
-```erb
-<!-- app/views/shared/whatever.html.erb -->
-  
-<%- record_cruft_tracker_view_render(instance_variables) %>
-
-<div>I am a partial. Hear me roar.</div>
-
-<div><%= some_value %></div>
-```
+You may want to think twice about using this method, or using this method too widely as it may create more data than you expect. CruftTracker is lightweight, but too much of a good thing is still too much. Generally, you should favor being targeted in your tracking.
 
 ### Clean Up
 
-CruftTacker automatically cleans up after itself. ✨🧹 If you remove any configured tracking, CruftTracker will recognize this when your application starts up and mark the associated `cruft_tracker_methods` record as deleted. 
+CruftTacker automatically cleans up after itself. ✨🧹 If you remove an instance of `CruftTracker.is_this_method_used?` to stop tracking a method, CruftTracker will recognize this when your application starts up and mark the associated `cruft_tracker_methods` record as deleted. But, only in environments where eager loading is enabled.
 
 ## API Docs
 
@@ -559,10 +369,10 @@ Returns an array of `CruftTracker::Method` instances.
 
 ##### Arguments
 
-| Name               | Type                                    | Required? | Default | Description                                                  |
-| ------------------ | :-------------------------------------- | --------- | ------- | ------------------------------------------------------------ |
-| owner (positional) | a class or module constant              | yes       | N/A     | A reference to the class or module that owns the method. Set this to `self`. |
-| comment: (named)   | anything that can be serialized to json | no        | nil     | Arbitrary data you want to include with the `cruft_tracker_methods` record. For example, a note about why the method is being tracked or a hash with keys indicating who is tracking the method and and why. |
+| Name                     | Type                                    | Required? | Default | Description                                                                                                                                                                                                  |
+| ------------------------ | --------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| owner (positional)       | a class or module constant              | yes       | N/A     | A reference to the class or module that owns the method. Set this to `self`.                                                                                                                                 |
+| comment: (named)         | anything that can be serialized to json | no        | nil     | Arbitrary data you want to include with the `cruft_tracker_methods` record. For example, a note about why the method is being tracked or a hash with keys indicating who is tracking the method and and why. |
 
 ## Developing
 
@@ -647,9 +457,9 @@ gem push cruft_tracker-x.y.z.gem
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/AdWerx/cruft-tracker.
+Bug reports and pull requests are welcome on GitHub at https://github.com/AdWerx/cruft-tracker
 
-Contributions should use Prettier to format Ruby code and must have tests covering any new features. All unit tests must pass for all supported versions of Rails.
+Contributions should use Prettier to format Ruby code. You can run Prettier in Docker with `bundle exec rbprettier --write '**/*.rb'`. Contributions must have tests covering any new features. All unit tests must pass for all supported versions of Rails.
 
 ## License
 

--- a/app/controllers/cruft_tracker/methods_controller.rb
+++ b/app/controllers/cruft_tracker/methods_controller.rb
@@ -2,9 +2,7 @@
 
 module CruftTracker
   class MethodsController < ApplicationController
-
     def index
-      
     end
   end
 end

--- a/app/helpers/cruft_tracker/application_helper.rb
+++ b/app/helpers/cruft_tracker/application_helper.rb
@@ -17,7 +17,7 @@ module CruftTracker
     private
 
     def cruft_tracker_view
-      path = render_stack.first[:path].gsub(/#{Rails.root}\//, "")
+      path = render_stack.first[:path].gsub(%r{#{Rails.root}/}, '')
       view = CruftTracker::View.find_by(view: path)
 
       return view if view.present?
@@ -26,9 +26,9 @@ module CruftTracker
     end
 
     def route_path
-      _routes.router.recognize(request) do |route, _|
-        return route.path.spec.to_s
-      end
+      _routes
+        .router
+        .recognize(request) { |route, _| return route.path.spec.to_s }
 
       nil
     end
@@ -38,18 +38,20 @@ module CruftTracker
     end
 
     def render_stack
-      caller_locations.select do |caller_location|
-        paths_to_views.any? do |path_for_view|
-          caller_location.path.match?(/^#{path_for_view}\//)
+      caller_locations
+        .select do |caller_location|
+          paths_to_views.any? do |path_for_view|
+            caller_location.path.match?(%r{^#{path_for_view}/})
+          end
         end
-      end.map do |location|
-        {
-          path: location.path,
-          label: location.label,
-          base_label: location.base_label,
-          lineno: location.lineno
-        }
-      end
+        .map do |location|
+          {
+            path: location.path,
+            label: location.label,
+            base_label: location.base_label,
+            lineno: location.lineno
+          }
+        end
     end
   end
 end

--- a/app/models/cruft_tracker/render_metadata.rb
+++ b/app/models/cruft_tracker/render_metadata.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CruftTracker
-  class RenderMetadata  < ActiveRecord::Base
+  class RenderMetadata < ActiveRecord::Base
     belongs_to :view_render, class_name: 'CruftTracker::ViewRender'
   end
 end

--- a/app/models/cruft_tracker/view.rb
+++ b/app/models/cruft_tracker/view.rb
@@ -11,7 +11,9 @@ module CruftTracker
 
     def still_tracked?
       return true if CruftTracker::Registry.include?(self)
-      return true if File.read(absolute_path).match?(/record_cruft_tracker_view_render/)
+      if File.read(absolute_path).match?(/record_cruft_tracker_view_render/)
+        return true
+      end
 
       false
     end

--- a/app/services/cruft_tracker/cleanup_untracked_views.rb
+++ b/app/services/cruft_tracker/cleanup_untracked_views.rb
@@ -9,10 +9,10 @@ module CruftTracker
         CruftTracker::View
           .where(deleted_at: nil)
           .each do |view|
-          unless view.still_exists? && view.still_tracked?
-            view.update(deleted_at: Time.current)
+            unless view.still_exists? && view.still_tracked?
+              view.update(deleted_at: Time.current)
+            end
           end
-        end
       end
     rescue StandardError
       # I'm actively ignoring all errors. Chances are, these are due to something like running rake

--- a/app/services/cruft_tracker/record_render_metadata.rb
+++ b/app/services/cruft_tracker/record_render_metadata.rb
@@ -14,7 +14,9 @@ module CruftTracker
       CruftTracker::LogSuppressor.suppress_logging do
         render_metadata_record.with_lock do
           render_metadata_record.reload
-          render_metadata_record.update(occurrences: render_metadata_record.occurrences + 1)
+          render_metadata_record.update(
+            occurrences: render_metadata_record.occurrences + 1
+          )
         end
       end
     end

--- a/app/services/cruft_tracker/record_view_render.rb
+++ b/app/services/cruft_tracker/record_view_render.rb
@@ -28,7 +28,9 @@ module CruftTracker
 
         view_render_record.with_lock do
           view_render_record.reload
-          view_render_record.update(occurrences: view_render_record.occurrences + 1)
+          view_render_record.update(
+            occurrences: view_render_record.occurrences + 1
+          )
 
           record_render_metadata(view_render_record)
 
@@ -38,9 +40,11 @@ module CruftTracker
     end
 
     def record_render_metadata(view_render_record)
-      compose(CruftTracker::RecordRenderMetadata,
-              view_render: view_render_record,
-              metadata: metadata)
+      compose(
+        CruftTracker::RecordRenderMetadata,
+        view_render: view_render_record,
+        metadata: metadata
+      )
     end
 
     def view_render_record
@@ -71,6 +75,5 @@ module CruftTracker
         }.to_json
       )
     end
-
   end
 end

--- a/app/services/cruft_tracker/track_view.rb
+++ b/app/services/cruft_tracker/track_view.rb
@@ -9,13 +9,14 @@ module CruftTracker
     interface :comment, methods: %i[to_json], default: nil
 
     def execute
-      view_record = CruftTracker::LogSuppressor.suppress_logging do
-        view_record = create_or_find_view_record
-        view_record.deleted_at = nil
-        view_record.comment = comment if comment != view_record.comment
-        view_record.save
-        view_record
-      end
+      view_record =
+        CruftTracker::LogSuppressor.suppress_logging do
+          view_record = create_or_find_view_record
+          view_record.deleted_at = nil
+          view_record.comment = comment if comment != view_record.comment
+          view_record.save
+          view_record
+        end
 
       listen_for_render(view_record)
 
@@ -33,7 +34,7 @@ module CruftTracker
         'CruftTracker was unable to record a view. Have migrations been run?'
       )
     rescue Mysql2::Error::ConnectionError,
-      ActiveRecord::ConnectionNotEstablished
+           ActiveRecord::ConnectionNotEstablished
       Rails.logger.warn(
         'CruftTracker was unable to record a view due to being unable to connect to the database. This may be a non-issue in cases where the database is intentionally not available.'
       )
@@ -51,14 +52,9 @@ module CruftTracker
     end
 
     def create_or_find_view_record
-      CruftTracker::View.create(
-        view: view,
-        comment: comment
-      )
+      CruftTracker::View.create(view: view, comment: comment)
     rescue ActiveRecord::RecordNotUnique
-      CruftTracker::View.find_by(
-        view: view
-      )
+      CruftTracker::View.find_by(view: view)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,1 @@
-CruftTracker::Engine.routes.draw do
-  resources :methods, only: %i[index]
-end
+CruftTracker::Engine.routes.draw { resources :methods, only: %i[index] }

--- a/cruft_tracker.gemspec
+++ b/cruft_tracker.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rails', '~> 2.12.4'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.5.0'
+  spec.add_development_dependency 'prettier'
 end

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cruft_tracker (0.1.4)
+    cruft_tracker (0.2.0)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 
@@ -76,6 +76,9 @@ GEM
       railties (>= 3.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    haml (5.2.2)
+      temple (>= 0.8.0)
+      tilt
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     loofah (2.16.0)
@@ -94,6 +97,11 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    prettier (3.1.2)
+      syntax_tree (>= 2.3.1)
+      syntax_tree-haml (>= 1.1.0)
+      syntax_tree-rbs (>= 0.2.0)
+    prettier_print (0.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -130,6 +138,7 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.1.1)
     rake (10.5.0)
+    rbs (2.6.0)
     regexp_parser (2.3.0)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -180,8 +189,20 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    syntax_tree (3.0.0)
+      prettier_print
+    syntax_tree-haml (1.2.0)
+      haml (>= 5.2)
+      prettier_print
+      syntax_tree (>= 2.0.1)
+    syntax_tree-rbs (0.4.0)
+      prettier_print
+      rbs
+      syntax_tree (>= 2.0.1)
+    temple (0.8.2)
     thor (1.2.1)
     thread_safe (0.3.6)
+    tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (2.1.0)
@@ -200,6 +221,7 @@ DEPENDENCIES
   database_cleaner (~> 2.0.1)
   generator_spec (~> 0.9.4)
   mysql2 (~> 0.5.3)
+  prettier
   pry-byebug (~> 3.9)
   rails (~> 5.2.4)
   rake (~> 10.0)

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cruft_tracker (0.1.4)
+    cruft_tracker (0.2.0)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 
@@ -89,6 +89,9 @@ GEM
       railties (>= 3.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    haml (5.2.2)
+      temple (>= 0.8.0)
+      tilt
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     loofah (2.16.0)
@@ -107,6 +110,11 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    prettier (3.1.2)
+      syntax_tree (>= 2.3.1)
+      syntax_tree-haml (>= 1.1.0)
+      syntax_tree-rbs (>= 0.2.0)
+    prettier_print (0.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -145,6 +153,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.1.1)
     rake (10.5.0)
+    rbs (2.6.0)
     regexp_parser (2.3.0)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -195,8 +204,20 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    syntax_tree (3.0.0)
+      prettier_print
+    syntax_tree-haml (1.2.0)
+      haml (>= 5.2)
+      prettier_print
+      syntax_tree (>= 2.0.1)
+    syntax_tree-rbs (0.4.0)
+      prettier_print
+      rbs
+      syntax_tree (>= 2.0.1)
+    temple (0.8.2)
     thor (1.2.1)
     thread_safe (0.3.6)
+    tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (2.1.0)
@@ -216,6 +237,7 @@ DEPENDENCIES
   database_cleaner (~> 2.0.1)
   generator_spec (~> 0.9.4)
   mysql2 (~> 0.5.3)
+  prettier
   pry-byebug (~> 3.9)
   rails (~> 6.0.3)
   rake (~> 10.0)

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cruft_tracker (0.1.4)
+    cruft_tracker (0.2.0)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 
@@ -93,6 +93,9 @@ GEM
       railties (>= 3.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    haml (5.2.2)
+      temple (>= 0.8.0)
+      tilt
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     loofah (2.16.0)
@@ -111,6 +114,11 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    prettier (3.1.2)
+      syntax_tree (>= 2.3.1)
+      syntax_tree-haml (>= 1.1.0)
+      syntax_tree-rbs (>= 0.2.0)
+    prettier_print (0.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -149,6 +157,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (10.5.0)
+    rbs (2.6.0)
     regexp_parser (2.3.0)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -199,7 +208,19 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    syntax_tree (3.0.0)
+      prettier_print
+    syntax_tree-haml (1.2.0)
+      haml (>= 5.2)
+      prettier_print
+      syntax_tree (>= 2.0.1)
+    syntax_tree-rbs (0.4.0)
+      prettier_print
+      rbs
+      syntax_tree (>= 2.0.1)
+    temple (0.8.2)
     thor (1.2.1)
+    tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -219,6 +240,7 @@ DEPENDENCIES
   database_cleaner (~> 2.0.1)
   generator_spec (~> 0.9.4)
   mysql2 (~> 0.5.3)
+  prettier
   pry-byebug (~> 3.9)
   rails (~> 6.1.0)
   rake (~> 10.0)

--- a/lib/cruft_tracker.rb
+++ b/lib/cruft_tracker.rb
@@ -8,14 +8,8 @@ module CruftTracker
     self.instance_eval(&block)
   end
 
-  def self.is_this_view_used?(
-    view,
-    comment: nil
-  )
-    CruftTracker::TrackView.run!(
-      view: view,
-      comment: comment
-    )
+  def self.is_this_view_used?(view, comment: nil)
+    CruftTracker::TrackView.run!(view: view, comment: comment)
   end
 
   def self.is_this_method_used?(

--- a/lib/cruft_tracker/engine.rb
+++ b/lib/cruft_tracker/engine.rb
@@ -14,6 +14,5 @@ module CruftTracker
         helper CruftTracker::ApplicationHelper
       end
     end
-
   end
 end

--- a/spec/app/helpers/cruft_tracker/application_helper_spec.rb
+++ b/spec/app/helpers/cruft_tracker/application_helper_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
-
 RSpec.describe CruftTracker::ApplicationHelper, type: :request do
   # This helper method is tested via a request spec to avoid excessive mocking/stubbing. This is
   # more of an integration test, but it shows that the helper is working.
   describe '#record_cruft_tracker_view_render' do
     context 'when no errors occur' do
       it 'records metadata for the associated view' do
-        view = CruftTracker::View.create(
-          view: "app/views/numbers/show.html.erb"
-        )
+        view =
+          CruftTracker::View.create(view: 'app/views/numbers/show.html.erb')
 
-        expect do
-          get number_path(123)
-        end.to change { CruftTracker::ViewRender.count }.by(1)
+        expect do get number_path(123) end.to change {
+          CruftTracker::ViewRender.count
+        }.by(1)
 
         view_render = view.view_renders.first
         expect(view_render.controller).to eq('NumbersController')
@@ -25,7 +23,10 @@ RSpec.describe CruftTracker::ApplicationHelper, type: :request do
       context 'with metadata' do
         it 'records the metadata for the request' do
           view = CruftTracker::View.create(view: 'app/views/main/show.html.erb')
-          partial = CruftTracker::View.create(view: 'app/views/shared/_whatever.html.erb')
+          partial =
+            CruftTracker::View.create(
+              view: 'app/views/shared/_whatever.html.erb'
+            )
 
           get main_path
           get main_path
@@ -36,34 +37,41 @@ RSpec.describe CruftTracker::ApplicationHelper, type: :request do
           expect(view.view_renders.count).to eq(1)
           expect(view.view_renders.first.occurrences).to eq(2)
           expect(view.view_renders.first.render_metadata.count).to eq(2)
-          expect(view.view_renders.first.render_metadata.first.occurrences).to eq(1)
-          expect(view.view_renders.first.render_metadata.second.occurrences).to eq(1)
+          expect(
+            view.view_renders.first.render_metadata.first.occurrences
+          ).to eq(1)
+          expect(
+            view.view_renders.first.render_metadata.second.occurrences
+          ).to eq(1)
           expect(partial.renders).to eq(2)
           expect(partial.view_renders.count).to eq(1)
           expect(partial.view_renders.first.occurrences).to eq(2)
           expect(partial.view_renders.first.render_metadata.count).to eq(1)
-          expect(partial.view_renders.first.render_metadata.first.occurrences).to eq(2)
-          expect(partial.view_renders.first.render_metadata.first.metadata).to eq("test"=>123)
+          expect(
+            partial.view_renders.first.render_metadata.first.occurrences
+          ).to eq(2)
+          expect(
+            partial.view_renders.first.render_metadata.first.metadata
+          ).to eq('test' => 123)
         end
       end
     end
 
     context 'when a view record does not already exist' do
       it 'creates one' do
-        expect do
-          get number_path(123)
-        end.to change { CruftTracker::View.count }.by(1).
-          and(change  { CruftTracker::ViewRender.count }.by(1))
+        expect do get number_path(123) end.to change {
+          CruftTracker::View.count
+        }.by(1).and(change { CruftTracker::ViewRender.count }.by(1))
       end
     end
 
     context 'when an error occurs in tracking' do
       it 'is suppressed' do
-        allow(CruftTracker::RecordViewRender).to receive(:run!).and_raise("💣KABOOOOOOOOM!💥")
+        allow(CruftTracker::RecordViewRender).to receive(:run!).and_raise(
+          '💣KABOOOOOOOOM!💥'
+        )
 
-        expect do
-          get number_path(123)
-        end.not_to raise_error
+        expect do get number_path(123) end.not_to raise_error
       end
     end
   end

--- a/spec/app/models/cruft_tracker/view_spec.rb
+++ b/spec/app/models/cruft_tracker/view_spec.rb
@@ -4,13 +4,17 @@ RSpec.describe CruftTracker::View do
   describe '#still_exists?' do
     it 'returns false for a view that does not exist' do
       expect(
-        CruftTracker::View.new(view: 'app/views/numbers/foo.html.erb').still_exists?
+        CruftTracker::View.new(
+          view: 'app/views/numbers/foo.html.erb'
+        ).still_exists?
       ).to eq(false)
     end
 
     it 'returns true for a view that exists' do
       expect(
-        CruftTracker::View.new(view: 'app/views/numbers/index.html.erb').still_exists?
+        CruftTracker::View.new(
+          view: 'app/views/numbers/index.html.erb'
+        ).still_exists?
       ).to eq(true)
     end
   end

--- a/spec/app/services/cruft_tracker/cleanup_untracked_methods_spec.rb
+++ b/spec/app/services/cruft_tracker/cleanup_untracked_methods_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe(CruftTracker::CleanupUntrackedMethods) do
       )
 
       # This tracks a real class with a real method (only this should survive cleanup)
-      CruftTracker.is_this_method_used?(ClassWithTaggedInstanceMethod, :some_instance_method)
+      CruftTracker.is_this_method_used?(
+        ClassWithTaggedInstanceMethod,
+        :some_instance_method
+      )
 
       CruftTracker::CleanupUntrackedMethods.run!
 

--- a/spec/app/services/cruft_tracker/cleanup_untracked_views_spec.rb
+++ b/spec/app/services/cruft_tracker/cleanup_untracked_views_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe CruftTracker::CleanupUntrackedViews do
   describe '#run!' do
     it 'deletes view records for views that are no longer tracked' do
-      untracked_view = CruftTracker::View.create(view: 'app/views/numbers/index.html.erb')
-      tracked_view = CruftTracker::TrackView.run!(view: 'app/views/numbers/show.html.erb')
+      untracked_view =
+        CruftTracker::View.create(view: 'app/views/numbers/index.html.erb')
+      tracked_view =
+        CruftTracker::TrackView.run!(view: 'app/views/numbers/show.html.erb')
 
       CruftTracker::CleanupUntrackedViews.run!
 

--- a/spec/app/services/cruft_tracker/increment_view_renders_spec.rb
+++ b/spec/app/services/cruft_tracker/increment_view_renders_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe CruftTracker::IncrementViewRenders do
   describe '#run!' do
     it 'records that a view was rendered' do
-      view = CruftTracker::View.create(view: 'app/views/main/some_view.html.erb')
+      view =
+        CruftTracker::View.create(view: 'app/views/main/some_view.html.erb')
 
       CruftTracker::IncrementViewRenders.run!(view: view)
 

--- a/spec/app/services/cruft_tracker/record_render_metadata_spec.rb
+++ b/spec/app/services/cruft_tracker/record_render_metadata_spec.rb
@@ -5,15 +5,16 @@ RSpec.describe CruftTracker::RecordRenderMetadata do
     context 'with no metadata' do
       it 'does nothing' do
         view = CruftTracker::View.create(view: 'some/view.html.erb')
-        view_render = CruftTracker::ViewRender.create(
-          view: view,
-          render_hash: '123',
-          controller: 'SomeController',
-          endpoint: 'some_endpoint',
-          route: '/foo',
-          http_method: 'POST',
-          render_stack: []
-        )
+        view_render =
+          CruftTracker::ViewRender.create(
+            view: view,
+            render_hash: '123',
+            controller: 'SomeController',
+            endpoint: 'some_endpoint',
+            route: '/foo',
+            http_method: 'POST',
+            render_stack: []
+          )
 
         expect do
           CruftTracker::RecordRenderMetadata.run!(
@@ -27,20 +28,23 @@ RSpec.describe CruftTracker::RecordRenderMetadata do
     context 'with new metadata' do
       it 'creates new a metadata record' do
         view = CruftTracker::View.create(view: 'some/view.html.erb')
-        view_render = CruftTracker::ViewRender.create(
-          view: view,
-          render_hash: '123',
-          controller: 'SomeController',
-          endpoint: 'some_endpoint',
-          route: '/foo',
-          http_method: 'DELETE',
-          render_stack: []
-        )
+        view_render =
+          CruftTracker::ViewRender.create(
+            view: view,
+            render_hash: '123',
+            controller: 'SomeController',
+            endpoint: 'some_endpoint',
+            route: '/foo',
+            http_method: 'DELETE',
+            render_stack: []
+          )
 
         expect do
           CruftTracker::RecordRenderMetadata.run!(
             view_render: view_render,
-            metadata: { some: 'metadata' }
+            metadata: {
+              some: 'metadata'
+            }
           )
         end.to change { CruftTracker::RenderMetadata.count }.by(1)
       end
@@ -49,26 +53,32 @@ RSpec.describe CruftTracker::RecordRenderMetadata do
     context 'with existing metadata' do
       it 'increments the occurrences of the metadata' do
         view = CruftTracker::View.create(view: 'some/view.html.erb')
-        view_render = CruftTracker::ViewRender.create(
-          view: view,
-          render_hash: '123',
-          controller: 'SomeController',
-          endpoint: 'some_endpoint',
-          route: '/foo',
-          http_method: 'PUT',
-          render_stack: []
-        )
-        render_metadata = CruftTracker::RenderMetadata.create(
-          view_render: view_render,
-          metadata: { some: 'metadata' },
-          metadata_hash: '631de6c2b97ff87eb40526dd6f11bc92',
-          occurrences: 1
-        )
+        view_render =
+          CruftTracker::ViewRender.create(
+            view: view,
+            render_hash: '123',
+            controller: 'SomeController',
+            endpoint: 'some_endpoint',
+            route: '/foo',
+            http_method: 'PUT',
+            render_stack: []
+          )
+        render_metadata =
+          CruftTracker::RenderMetadata.create(
+            view_render: view_render,
+            metadata: {
+              some: 'metadata'
+            },
+            metadata_hash: '631de6c2b97ff87eb40526dd6f11bc92',
+            occurrences: 1
+          )
 
         expect do
           CruftTracker::RecordRenderMetadata.run!(
             view_render: view_render,
-            metadata: { some: 'metadata' }
+            metadata: {
+              some: 'metadata'
+            }
           )
 
           render_metadata.reload

--- a/spec/app/services/cruft_tracker/record_view_render_spec.rb
+++ b/spec/app/services/cruft_tracker/record_view_render_spec.rb
@@ -13,13 +13,16 @@ RSpec.describe CruftTracker::RecordViewRender do
             endpoint: 'show',
             route: '/some:id',
             http_method: 'GET',
-            render_stack:[
+            render_stack: [
               {
-                path: "/app/views/some/show.html.erb",
-                label: "_app_views_some_show_html_erb__1726455257671384410_11260",
+                path: '/app/views/some/show.html.erb',
+                label:
+                  '_app_views_some_show_html_erb__1726455257671384410_11260',
                 lineno: 1,
-                base_label: "_app_views_some_show_html_erb__1726455257671384410_11260"
-              }]
+                base_label:
+                  '_app_views_some_show_html_erb__1726455257671384410_11260'
+              }
+            ]
           )
         end.to change { CruftTracker::ViewRender.count }.by(1)
 
@@ -31,12 +34,14 @@ RSpec.describe CruftTracker::RecordViewRender do
         expect(view_render.http_method).to eq('GET')
         expect(view_render.render_stack).to eq(
           [
-             {
-               "path" => "/app/views/some/show.html.erb",
-               "label" => "_app_views_some_show_html_erb__1726455257671384410_11260",
-               "lineno" => 1,
-               "base_label" => "_app_views_some_show_html_erb__1726455257671384410_11260"
-             }
+            {
+              'path' => '/app/views/some/show.html.erb',
+              'label' =>
+                '_app_views_some_show_html_erb__1726455257671384410_11260',
+              'lineno' => 1,
+              'base_label' =>
+                '_app_views_some_show_html_erb__1726455257671384410_11260'
+            }
           ]
         )
         expect(view_render.occurrences).to eq(1)
@@ -48,26 +53,29 @@ RSpec.describe CruftTracker::RecordViewRender do
           metadata = { some_data: [1, true, { a: 'b' }], something_else: nil }
 
           expect do
-            view_render = CruftTracker::RecordViewRender.run!(
-              view: view,
-              controller: 'SomeController',
-              endpoint: 'show',
-              route: '/some:id',
-              http_method: 'GET',
-              render_stack:[
-                {
-                  path: "/app/views/some/show.html.erb",
-                  label: "_app_views_some_show_html_erb__1726455257671384410_11260",
-                  lineno: 1,
-                  base_label: "_app_views_some_show_html_erb__1726455257671384410_11260"
-                }],
-              metadata: metadata
-            )
+            view_render =
+              CruftTracker::RecordViewRender.run!(
+                view: view,
+                controller: 'SomeController',
+                endpoint: 'show',
+                route: '/some:id',
+                http_method: 'GET',
+                render_stack: [
+                  {
+                    path: '/app/views/some/show.html.erb',
+                    label:
+                      '_app_views_some_show_html_erb__1726455257671384410_11260',
+                    lineno: 1,
+                    base_label:
+                      '_app_views_some_show_html_erb__1726455257671384410_11260'
+                  }
+                ],
+                metadata: metadata
+              )
 
             render_metadata = view_render.render_metadata.first
             expect(render_metadata.metadata_hash).not_to be_nil
             expect(render_metadata.occurrences).to eq(1)
-
           end.to change { CruftTracker::RenderMetadata.count }.by(1)
         end
       end
@@ -82,31 +90,34 @@ RSpec.describe CruftTracker::RecordViewRender do
         http_method = 'GET'
         render_stack = [
           {
-            path: "/app/views/some/show.html.erb",
-            label: "_app_views_some_show_html_erb__1726455257671384410_11260",
-            base_label: "_app_views_some_show_html_erb__1726455257671384410_11260",
+            path: '/app/views/some/show.html.erb',
+            label: '_app_views_some_show_html_erb__1726455257671384410_11260',
+            base_label:
+              '_app_views_some_show_html_erb__1726455257671384410_11260',
             lineno: 1
           }
         ]
-        render_hash = Digest::MD5.hexdigest(
-          {
+        render_hash =
+          Digest::MD5.hexdigest(
+            {
+              controller: controller,
+              endpoint: endpoint,
+              route: route,
+              http_method: http_method,
+              render_stack: render_stack.to_json
+            }.to_json
+          )
+        view_render =
+          CruftTracker::ViewRender.create(
+            view: view,
+            render_hash: render_hash,
             controller: controller,
             endpoint: endpoint,
             route: route,
             http_method: http_method,
-            render_stack: render_stack.to_json
-          }.to_json
-        )
-        view_render = CruftTracker::ViewRender.create(
-          view: view,
-          render_hash: render_hash,
-          controller: controller,
-          endpoint: endpoint,
-          route: route,
-          http_method: http_method,
-          render_stack: render_stack,
-          occurrences: 123
-        )
+            render_stack: render_stack,
+            occurrences: 123
+          )
 
         expect do
           CruftTracker::RecordViewRender.run!(
@@ -128,10 +139,12 @@ RSpec.describe CruftTracker::RecordViewRender do
         expect(view_render.render_stack).to eq(
           [
             {
-              "path" => "/app/views/some/show.html.erb",
-              "label" => "_app_views_some_show_html_erb__1726455257671384410_11260",
-              "lineno" => 1,
-              "base_label" => "_app_views_some_show_html_erb__1726455257671384410_11260"
+              'path' => '/app/views/some/show.html.erb',
+              'label' =>
+                '_app_views_some_show_html_erb__1726455257671384410_11260',
+              'lineno' => 1,
+              'base_label' =>
+                '_app_views_some_show_html_erb__1726455257671384410_11260'
             }
           ]
         )
@@ -148,38 +161,43 @@ RSpec.describe CruftTracker::RecordViewRender do
           http_method = 'GET'
           render_stack = [
             {
-              path: "/app/views/some/show.html.erb",
-              label: "_app_views_some_show_html_erb__1726455257671384410_11260",
-              base_label: "_app_views_some_show_html_erb__1726455257671384410_11260",
+              path: '/app/views/some/show.html.erb',
+              label: '_app_views_some_show_html_erb__1726455257671384410_11260',
+              base_label:
+                '_app_views_some_show_html_erb__1726455257671384410_11260',
               lineno: 1
             }
           ]
-          render_hash = Digest::MD5.hexdigest(
-            {
+          render_hash =
+            Digest::MD5.hexdigest(
+              {
+                controller: controller,
+                endpoint: endpoint,
+                route: route,
+                http_method: http_method,
+                render_stack: render_stack.to_json
+              }.to_json
+            )
+          view_render =
+            CruftTracker::ViewRender.create(
+              view: view,
+              render_hash: render_hash,
               controller: controller,
               endpoint: endpoint,
               route: route,
               http_method: http_method,
-              render_stack: render_stack.to_json
-            }.to_json
-          )
-          view_render = CruftTracker::ViewRender.create(
-            view: view,
-            render_hash: render_hash,
-            controller: controller,
-            endpoint: endpoint,
-            route: route,
-            http_method: http_method,
-            render_stack: render_stack,
-            occurrences: 123
-          )
-          metadata_hash = Digest::MD5.hexdigest([view_render.render_hash, metadata].to_json)
-          render_metadata = CruftTracker::RenderMetadata.create(
-            view_render: view_render,
-            metadata_hash: metadata_hash,
-            metadata: metadata,
-            occurrences: 234
-          )
+              render_stack: render_stack,
+              occurrences: 123
+            )
+          metadata_hash =
+            Digest::MD5.hexdigest([view_render.render_hash, metadata].to_json)
+          render_metadata =
+            CruftTracker::RenderMetadata.create(
+              view_render: view_render,
+              metadata_hash: metadata_hash,
+              metadata: metadata,
+              occurrences: 234
+            )
 
           expect do
             CruftTracker::RecordViewRender.run!(

--- a/spec/app/services/cruft_tracker/track_all_methods_spec.rb
+++ b/spec/app/services/cruft_tracker/track_all_methods_spec.rb
@@ -13,11 +13,9 @@ RSpec.describe(CruftTracker::TrackAllMethods) do
         ActiveRecord::Base.connection.execute(
           'RENAME TABLE cruft_tracker_methods TO tmp_cruft_tracker_methods'
         )
-        expect(Rails.logger).to receive(:warn)
-          .with(
-            'CruftTracker was unable to record a method. Does the cruft_tracker_methods table exist? Have migrations been run?'
-          )
-          .at_least(:once)
+        expect(Rails.logger).to receive(:warn).with(
+          'CruftTracker was unable to record a method. Does the cruft_tracker_methods table exist? Have migrations been run?'
+        ).at_least(:once)
 
         CruftTracker::TrackAllMethods.run!(owner: ClassWithTaggedInstanceMethod)
       end

--- a/spec/app/services/cruft_tracker/track_method_spec.rb
+++ b/spec/app/services/cruft_tracker/track_method_spec.rb
@@ -13,11 +13,9 @@ RSpec.describe(CruftTracker::TrackMethod) do
         ActiveRecord::Base.connection.execute(
           'RENAME TABLE cruft_tracker_methods TO tmp_cruft_tracker_methods'
         )
-        expect(Rails.logger).to receive(:warn)
-          .with(
-            'CruftTracker was unable to record a method. Does the cruft_tracker_methods table exist? Have migrations been run?'
-          )
-          .at_least(:once)
+        expect(Rails.logger).to receive(:warn).with(
+          'CruftTracker was unable to record a method. Does the cruft_tracker_methods table exist? Have migrations been run?'
+        ).at_least(:once)
 
         CruftTracker::TrackMethod.run!(
           owner: ClassWithTaggedInstanceMethod,

--- a/spec/app/services/cruft_tracker/track_view_spec.rb
+++ b/spec/app/services/cruft_tracker/track_view_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe CruftTracker::TrackView do
   describe '#run!' do
     context 'without an existing view record' do
       it 'creates a view record and configures a render subscription' do
-        expect(ActiveSupport::Notifications).to receive(:subscribe).with(instance_of(Regexp))
+        expect(ActiveSupport::Notifications).to receive(:subscribe).with(
+          instance_of(Regexp)
+        )
 
         expect do
           CruftTracker::TrackView.run!(view: 'some/view.html.erb')
@@ -15,7 +17,9 @@ RSpec.describe CruftTracker::TrackView do
     context 'with an existing view record' do
       it 'configures a render subscription' do
         CruftTracker::View.create(view: 'some/view.html.erb')
-        expect(ActiveSupport::Notifications).to receive(:subscribe).with(instance_of(Regexp))
+        expect(ActiveSupport::Notifications).to receive(:subscribe).with(
+          instance_of(Regexp)
+        )
 
         expect do
           CruftTracker::TrackView.run!(view: 'some/view.html.erb')
@@ -25,8 +29,14 @@ RSpec.describe CruftTracker::TrackView do
 
     context 'when the view record has been deleted' do
       it 'undeletes the view record' do
-        view = CruftTracker::View.create(view: 'some/view.html.erb', deleted_at: Time.current)
-        expect(ActiveSupport::Notifications).to receive(:subscribe).with(instance_of(Regexp))
+        view =
+          CruftTracker::View.create(
+            view: 'some/view.html.erb',
+            deleted_at: Time.current
+          )
+        expect(ActiveSupport::Notifications).to receive(:subscribe).with(
+          instance_of(Regexp)
+        )
 
         CruftTracker::TrackView.run!(view: 'some/view.html.erb')
 

--- a/spec/dummy/app/controllers/main_controller.rb
+++ b/spec/dummy/app/controllers/main_controller.rb
@@ -4,7 +4,7 @@ class MainController < ApplicationController
   helper_method :uuid
 
   def show
-    @name = "Zamboni Overdrive"
+    @name = 'Zamboni Overdrive'
     @some_value = ClassWithTextualComment.new.some_method
   end
 

--- a/spec/dummy/app/controllers/numbers_controller.rb
+++ b/spec/dummy/app/controllers/numbers_controller.rb
@@ -10,6 +10,6 @@ class NumbersController < ApplicationController
   def present
     @number = NUMBERS[params[:id].to_i]
 
-    render "show"
+    render 'show'
   end
 end

--- a/spec/dummy/app/models/class_tracking_method_that_does_not_exist.rb
+++ b/spec/dummy/app/models/class_tracking_method_that_does_not_exist.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ClassTrackingMethodThatDoesNotExist
-
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,24 +1,24 @@
-require_relative "boot"
+require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
+require 'active_model/railtie'
 # require "active_job/railtie"
-require "active_record/railtie"
+require 'active_record/railtie'
 # require "active_storage/engine"
-require "action_controller/railtie"
+require 'action_controller/railtie'
 # require "action_mailer/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
-require "action_view/railtie"
+require 'action_view/railtie'
 # require "action_cable/engine"
-require "sprockets/railtie"
+require 'sprockets/railtie'
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-require "cruft_tracker"
+require 'cruft_tracker'
 
 module Dummy
   class Application < Rails::Application

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
@@ -45,11 +45,10 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -71,10 +70,10 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -22,7 +22,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/spec/dummy/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy/config/initializers/backtrace_silencers.rb
@@ -5,4 +5,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]
+Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']

--- a/spec/dummy/config/initializers/cruft_tracker.rb
+++ b/spec/dummy/config/initializers/cruft_tracker.rb
@@ -4,12 +4,16 @@ CruftTracker.init do
   # - max backtrace stack
   # - filters for backtraces
 
-  is_this_method_used?(ClassWithClassAndInstanceMethodsOfTheSameName,
-                       :some_ambiguous_method_name,
-                       method_type: CruftTracker::Method::CLASS_METHOD)
-  is_this_method_used?(ClassWithClassAndInstanceMethodsOfTheSameName,
-                       :some_ambiguous_method_name,
-                       method_type: CruftTracker::Method::INSTANCE_METHOD)
+  is_this_method_used?(
+    ClassWithClassAndInstanceMethodsOfTheSameName,
+    :some_ambiguous_method_name,
+    method_type: CruftTracker::Method::CLASS_METHOD
+  )
+  is_this_method_used?(
+    ClassWithClassAndInstanceMethodsOfTheSameName,
+    :some_ambiguous_method_name,
+    method_type: CruftTracker::Method::INSTANCE_METHOD
+  )
 
   is_this_method_used?(
     ClassWithHashComment,
@@ -23,27 +27,41 @@ CruftTracker.init do
   is_this_method_used?(
     ClassWithMethodThatAcceptsTrackedArguments,
     :do_something,
-    track_arguments: ->(args) {
-      args.last.keys.sort
-    }
+    track_arguments: ->(args) { args.last.keys.sort }
   )
 
-  is_this_method_used?(ClassWithMethodThatAcceptsUntrackedArguments, :describe_thing)
-  is_this_method_used?(ClassWithMultipleBacktracesToTheSameTrackedMethod, :tracked_method)
+  is_this_method_used?(
+    ClassWithMethodThatAcceptsUntrackedArguments,
+    :describe_thing
+  )
+  is_this_method_used?(
+    ClassWithMultipleBacktracesToTheSameTrackedMethod,
+    :tracked_method
+  )
   is_this_method_used?(ClassWithPrivateClassMethod, :be_sneaky)
-  is_this_method_used?(ClassWithPrivateEigenclassMethod, :super_private_class_method)
+  is_this_method_used?(
+    ClassWithPrivateEigenclassMethod,
+    :super_private_class_method
+  )
   is_this_method_used?(ClassWithPrivateInstanceMethod, :some_private_method)
   is_this_method_used?(ClassWithProtectedInstanceMethod, :some_protected_method)
   is_this_method_used?(ClassWithTaggedClassMethod, :some_class_method)
   is_this_method_used?(ClassWithTaggedInstanceMethod, :some_instance_method)
-  is_this_method_used?(ClassWithTextualComment, :some_method, comment: 'Tracking is fun!')
+  is_this_method_used?(
+    ClassWithTextualComment,
+    :some_method,
+    comment: 'Tracking is fun!'
+  )
   is_this_method_used?(ModuleWithTaggedMethod, :some_module_method)
   is_this_method_used?(SubclassWithTrackedMethod, :hello)
 
   are_any_of_these_methods_being_used?(ClassThatIsTrackingAllMethods)
   are_any_of_these_methods_being_used?(ModuleThatIsTrackingAllMethods)
 
-  is_this_view_used?('app/views/main/show.html.erb', comment: "Look at that view!")
+  is_this_view_used?(
+    'app/views/main/show.html.erb',
+    comment: 'Look at that view!'
+  )
   is_this_view_used?('app/views/shared/_whatever.html.erb')
   is_this_view_used?('app/views/numbers/show.html.erb')
 end

--- a/spec/dummy/config/initializers/filter_parameter_logging.rb
+++ b/spec/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,14 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw
+  secret
+  token
+  _key
+  crypt
+  salt
+  certificate
+  otp
+  ssn
 ]

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -4,9 +4,7 @@
 # is enabled by default.
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
-end
+ActiveSupport.on_load(:action_controller) { wrap_parameters format: [:json] }
 
 # To enable root element in JSON for ActiveRecord objects.
 # ActiveSupport.on_load(:active_record) do

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount CruftTracker::Engine => "/cruft_tracker"
+  mount CruftTracker::Engine => '/cruft_tracker'
 
   get '/', to: 'main#show', as: :main
   resources :numbers, only: %i[index]

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,90 +11,122 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_07_05_152409) do
-
-  create_table "cruft_tracker_arguments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "method_id", null: false
-    t.string "arguments_hash", null: false
-    t.json "arguments", null: false
-    t.integer "occurrences", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["arguments_hash"], name: "index_cruft_tracker_arguments_on_arguments_hash"
-    t.index ["method_id", "arguments_hash"], name: "index_pca_on_method_id_and_arguments_hash", unique: true
-    t.index ["method_id"], name: "index_cruft_tracker_arguments_on_method_id"
-    t.index ["occurrences"], name: "index_cruft_tracker_arguments_on_occurrences"
+  create_table 'cruft_tracker_arguments',
+               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb3',
+               force: :cascade do |t|
+    t.bigint 'method_id', null: false
+    t.string 'arguments_hash', null: false
+    t.json 'arguments', null: false
+    t.integer 'occurrences', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['arguments_hash'],
+            name: 'index_cruft_tracker_arguments_on_arguments_hash'
+    t.index %w[method_id arguments_hash],
+            name: 'index_pca_on_method_id_and_arguments_hash',
+            unique: true
+    t.index ['method_id'], name: 'index_cruft_tracker_arguments_on_method_id'
+    t.index ['occurrences'],
+            name: 'index_cruft_tracker_arguments_on_occurrences'
   end
 
-  create_table "cruft_tracker_backtraces", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.string "traceable_type", null: false
-    t.bigint "traceable_id", null: false
-    t.string "trace_hash", null: false
-    t.json "trace", null: false
-    t.integer "occurrences", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["occurrences"], name: "index_cruft_tracker_backtraces_on_occurrences"
-    t.index ["trace_hash"], name: "index_cruft_tracker_backtraces_on_trace_hash"
-    t.index ["traceable_id", "trace_hash"], name: "index_pcbt_on_traceable_id_and_trace_hash", unique: true
-    t.index ["traceable_type", "traceable_id"], name: "index_pcbt_on_traceable_id_and_type"
+  create_table 'cruft_tracker_backtraces',
+               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb3',
+               force: :cascade do |t|
+    t.string 'traceable_type', null: false
+    t.bigint 'traceable_id', null: false
+    t.string 'trace_hash', null: false
+    t.json 'trace', null: false
+    t.integer 'occurrences', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['occurrences'],
+            name: 'index_cruft_tracker_backtraces_on_occurrences'
+    t.index ['trace_hash'], name: 'index_cruft_tracker_backtraces_on_trace_hash'
+    t.index %w[traceable_id trace_hash],
+            name: 'index_pcbt_on_traceable_id_and_trace_hash',
+            unique: true
+    t.index %w[traceable_type traceable_id],
+            name: 'index_pcbt_on_traceable_id_and_type'
   end
 
-  create_table "cruft_tracker_methods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.string "owner", null: false
-    t.string "name", null: false
-    t.string "method_type", null: false
-    t.integer "invocations", default: 0, null: false
-    t.json "comment"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_cruft_tracker_methods_on_name"
-    t.index ["owner", "name", "method_type"], name: "index_cruft_tracker_methods_on_owner_and_name_and_method_type", unique: true
-    t.index ["owner", "name"], name: "index_cruft_tracker_methods_on_owner_and_name"
-    t.index ["owner"], name: "index_cruft_tracker_methods_on_owner"
+  create_table 'cruft_tracker_methods',
+               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb3',
+               force: :cascade do |t|
+    t.string 'owner', null: false
+    t.string 'name', null: false
+    t.string 'method_type', null: false
+    t.integer 'invocations', default: 0, null: false
+    t.json 'comment'
+    t.datetime 'deleted_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['name'], name: 'index_cruft_tracker_methods_on_name'
+    t.index %w[owner name method_type],
+            name:
+              'index_cruft_tracker_methods_on_owner_and_name_and_method_type',
+            unique: true
+    t.index %w[owner name],
+            name: 'index_cruft_tracker_methods_on_owner_and_name'
+    t.index ['owner'], name: 'index_cruft_tracker_methods_on_owner'
   end
 
-  create_table "cruft_tracker_render_metadata", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "view_render_id", null: false
-    t.string "metadata_hash", null: false
-    t.json "metadata", null: false
-    t.integer "occurrences", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["metadata_hash"], name: "index_cruft_tracker_render_metadata_on_metadata_hash", unique: true
-    t.index ["occurrences"], name: "index_cruft_tracker_render_metadata_on_occurrences"
-    t.index ["view_render_id"], name: "index_cruft_tracker_render_metadata_on_view_render_id"
+  create_table 'cruft_tracker_render_metadata',
+               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb3',
+               force: :cascade do |t|
+    t.bigint 'view_render_id', null: false
+    t.string 'metadata_hash', null: false
+    t.json 'metadata', null: false
+    t.integer 'occurrences', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['metadata_hash'],
+            name: 'index_cruft_tracker_render_metadata_on_metadata_hash',
+            unique: true
+    t.index ['occurrences'],
+            name: 'index_cruft_tracker_render_metadata_on_occurrences'
+    t.index ['view_render_id'],
+            name: 'index_cruft_tracker_render_metadata_on_view_render_id'
   end
 
-  create_table "cruft_tracker_view_renders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "view_id", null: false
-    t.string "render_hash", null: false
-    t.string "controller", null: false
-    t.string "endpoint", null: false
-    t.string "route", null: false
-    t.string "http_method", null: false
-    t.json "render_stack", null: false
-    t.integer "occurrences", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["controller"], name: "index_cruft_tracker_view_renders_on_controller"
-    t.index ["endpoint"], name: "index_cruft_tracker_view_renders_on_endpoint"
-    t.index ["http_method"], name: "index_cruft_tracker_view_renders_on_http_method"
-    t.index ["occurrences"], name: "index_cruft_tracker_view_renders_on_occurrences"
-    t.index ["render_hash"], name: "index_cruft_tracker_view_renders_on_render_hash"
-    t.index ["route"], name: "index_cruft_tracker_view_renders_on_route"
-    t.index ["view_id", "render_hash"], name: "index_cruft_tracker_view_renders_on_view_id_and_render_hash", unique: true
-    t.index ["view_id"], name: "index_cruft_tracker_view_renders_on_view_id"
+  create_table 'cruft_tracker_view_renders',
+               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb3',
+               force: :cascade do |t|
+    t.bigint 'view_id', null: false
+    t.string 'render_hash', null: false
+    t.string 'controller', null: false
+    t.string 'endpoint', null: false
+    t.string 'route', null: false
+    t.string 'http_method', null: false
+    t.json 'render_stack', null: false
+    t.integer 'occurrences', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['controller'],
+            name: 'index_cruft_tracker_view_renders_on_controller'
+    t.index ['endpoint'], name: 'index_cruft_tracker_view_renders_on_endpoint'
+    t.index ['http_method'],
+            name: 'index_cruft_tracker_view_renders_on_http_method'
+    t.index ['occurrences'],
+            name: 'index_cruft_tracker_view_renders_on_occurrences'
+    t.index ['render_hash'],
+            name: 'index_cruft_tracker_view_renders_on_render_hash'
+    t.index ['route'], name: 'index_cruft_tracker_view_renders_on_route'
+    t.index %w[view_id render_hash],
+            name: 'index_cruft_tracker_view_renders_on_view_id_and_render_hash',
+            unique: true
+    t.index ['view_id'], name: 'index_cruft_tracker_view_renders_on_view_id'
   end
 
-  create_table "cruft_tracker_views", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.string "view", null: false
-    t.integer "renders", default: 0, null: false
-    t.json "comment"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["view"], name: "index_cruft_tracker_views_on_view", unique: true
+  create_table 'cruft_tracker_views',
+               options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb3',
+               force: :cascade do |t|
+    t.string 'view', null: false
+    t.integer 'renders', default: 0, null: false
+    t.json 'comment'
+    t.datetime 'deleted_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['view'], name: 'index_cruft_tracker_views_on_view', unique: true
   end
-
 end

--- a/spec/lib/cruft_tracker_spec.rb
+++ b/spec/lib/cruft_tracker_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe(CruftTracker) do
   describe '.is_this_method_used?' do
     it 'creates method records before methods are invoked' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithTaggedInstanceMethod, :some_instance_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithTaggedInstanceMethod,
+          :some_instance_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       method = CruftTracker::Method.first
@@ -19,7 +22,10 @@ RSpec.describe(CruftTracker) do
 
     it 'overrides instance methods on classes that tag methods with is_this_method_used?' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithTaggedInstanceMethod, :some_instance_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithTaggedInstanceMethod,
+          :some_instance_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       test_class = ClassWithTaggedInstanceMethod.new
@@ -41,7 +47,10 @@ RSpec.describe(CruftTracker) do
 
     it 'overrides class methods on classes that tag methods with is_this_method_used?' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithTaggedClassMethod, :some_class_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithTaggedClassMethod,
+          :some_class_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       result = ClassWithTaggedClassMethod.some_class_method
@@ -58,7 +67,10 @@ RSpec.describe(CruftTracker) do
 
     it 'overrides methods on modules that tag methods with is_this_method_used?' do
       expect do
-        CruftTracker.is_this_method_used?(ModuleWithTaggedMethod, :some_module_method)
+        CruftTracker.is_this_method_used?(
+          ModuleWithTaggedMethod,
+          :some_module_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       result = ModuleWithTaggedMethod.some_module_method
@@ -75,20 +87,23 @@ RSpec.describe(CruftTracker) do
 
     it 'allows the user to disambiguate between class and instance methods with the same name' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithClassAndInstanceMethodsOfTheSameName,
-                                          :some_ambiguous_method_name,
-                                          method_type: CruftTracker::Method::CLASS_METHOD)
+        CruftTracker.is_this_method_used?(
+          ClassWithClassAndInstanceMethodsOfTheSameName,
+          :some_ambiguous_method_name,
+          method_type: CruftTracker::Method::CLASS_METHOD
+        )
 
-        CruftTracker.is_this_method_used?(ClassWithClassAndInstanceMethodsOfTheSameName,
-                                          :some_ambiguous_method_name,
-                                          method_type: CruftTracker::Method::INSTANCE_METHOD)
+        CruftTracker.is_this_method_used?(
+          ClassWithClassAndInstanceMethodsOfTheSameName,
+          :some_ambiguous_method_name,
+          method_type: CruftTracker::Method::INSTANCE_METHOD
+        )
       end.to change { CruftTracker::Method.count }.by(2)
 
       class_result =
         ClassWithClassAndInstanceMethodsOfTheSameName.some_ambiguous_method_name
       instance_result =
-        ClassWithClassAndInstanceMethodsOfTheSameName.new
-          .some_ambiguous_method_name
+        ClassWithClassAndInstanceMethodsOfTheSameName.new.some_ambiguous_method_name
 
       expect(class_result).to eq(
         'I am the result of a class method invocation!'
@@ -130,15 +145,19 @@ RSpec.describe(CruftTracker) do
 
     it 'raises when trying to track a method that does not exist' do
       expect do
-        CruftTracker.is_this_method_used?(ClassTrackingMethodThatDoesNotExist,
-                                          :some_missing_method_name)
+        CruftTracker.is_this_method_used?(
+          ClassTrackingMethodThatDoesNotExist,
+          :some_missing_method_name
+        )
       end.to raise_error(CruftTracker::TrackMethod::NoSuchMethod)
     end
 
     it 'records distinct stack traces for method invocations' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithMultipleBacktracesToTheSameTrackedMethod,
-                                          :tracked_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithMultipleBacktracesToTheSameTrackedMethod,
+          :tracked_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       test_class = ClassWithMultipleBacktracesToTheSameTrackedMethod.new
@@ -167,7 +186,10 @@ RSpec.describe(CruftTracker) do
 
     it 'tracks private instance methods' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithPrivateInstanceMethod, :some_private_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithPrivateInstanceMethod,
+          :some_private_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       ClassWithPrivateInstanceMethod.new.do_something
@@ -180,7 +202,10 @@ RSpec.describe(CruftTracker) do
 
     it 'tracks protected instance methods' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithProtectedInstanceMethod, :some_protected_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithProtectedInstanceMethod,
+          :some_protected_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       ClassWithProtectedInstanceMethod.new.do_something
@@ -193,8 +218,10 @@ RSpec.describe(CruftTracker) do
 
     it 'tracks private eigenclass methods' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithPrivateEigenclassMethod,
-                                          :super_private_class_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithPrivateEigenclassMethod,
+          :super_private_class_method
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       ClassWithPrivateEigenclassMethod.do_it
@@ -208,7 +235,10 @@ RSpec.describe(CruftTracker) do
 
     it 'tracks private class methods' do
       expect do
-        CruftTracker.is_this_method_used?(ClassWithPrivateClassMethod, :be_sneaky)
+        CruftTracker.is_this_method_used?(
+          ClassWithPrivateClassMethod,
+          :be_sneaky
+        )
       end.to change { CruftTracker::Method.count }.by(1)
 
       ClassWithPrivateClassMethod.do_the_sneaky_thing
@@ -232,7 +262,8 @@ RSpec.describe(CruftTracker) do
                 'SomeClassName'
               end
 
-              def foo; end
+              def foo
+              end
               CruftTracker.is_this_method_used?(self, :foo)
             end
           end
@@ -251,7 +282,10 @@ RSpec.describe(CruftTracker) do
 
     it 'does not create multiple of the same stack record in a race condition' do
       starting_pistol_has_been_fired = false
-      CruftTracker.is_this_method_used?(ClassWithTaggedInstanceMethod, :some_instance_method)
+      CruftTracker.is_this_method_used?(
+        ClassWithTaggedInstanceMethod,
+        :some_instance_method
+      )
 
       threads =
         10.times.map do
@@ -292,8 +326,9 @@ RSpec.describe(CruftTracker) do
       expect(CruftTracker::Method.count).to eq(1)
       expect(method.reload.invocations).to eq(1)
 
-      SubSubclassWithUntrackedMethodThatCallsTrackedSuperMethod.new('Clair')
-        .hello
+      SubSubclassWithUntrackedMethodThatCallsTrackedSuperMethod.new(
+        'Clair'
+      ).hello
       expect(CruftTracker::Method.count).to eq(1)
       expect(method.reload.invocations).to eq(2)
     end
@@ -312,22 +347,25 @@ RSpec.describe(CruftTracker) do
 
         # Note using Zeitwerk with `load` as I am causes the class to be loaded twice. That's no big
         # deal, really. But that's why I'm asserting that we receive warn at least once.
-        expect(Rails.logger).to receive(:warn)
-          .with(
-            'CruftTracker was unable to record a method. Does the cruft_tracker_methods table exist? Have migrations been run?'
-          )
-          .at_least(:once)
+        expect(Rails.logger).to receive(:warn).with(
+          'CruftTracker was unable to record a method. Does the cruft_tracker_methods table exist? Have migrations been run?'
+        ).at_least(:once)
 
-        CruftTracker.is_this_method_used?(ClassWithTaggedInstanceMethod, :some_instance_method)
+        CruftTracker.is_this_method_used?(
+          ClassWithTaggedInstanceMethod,
+          :some_instance_method
+        )
       end
     end
 
     context 'with a comment' do
       context 'when the comment is text' do
         it 'writes text' do
-          CruftTracker.is_this_method_used?(ClassWithTextualComment,
-                                            :some_method,
-                                            comment: 'Tracking is fun!')
+          CruftTracker.is_this_method_used?(
+            ClassWithTextualComment,
+            :some_method,
+            comment: 'Tracking is fun!'
+          )
 
           method = CruftTracker::Method.first
 
@@ -362,7 +400,11 @@ RSpec.describe(CruftTracker) do
               comment: 'Some old comment'
             )
 
-          CruftTracker.is_this_method_used?(ClassWithTextualComment, :some_method, comment: 'Tracking is fun!')
+          CruftTracker.is_this_method_used?(
+            ClassWithTextualComment,
+            :some_method,
+            comment: 'Tracking is fun!'
+          )
 
           expect(method.reload.comment).to eq('Tracking is fun!')
         end
@@ -372,8 +414,10 @@ RSpec.describe(CruftTracker) do
     context 'when track_arguments is not provided' do
       it 'does not track arguments' do
         expect do
-          CruftTracker.is_this_method_used?(ClassWithMethodThatAcceptsUntrackedArguments,
-                                            :describe_thing)
+          CruftTracker.is_this_method_used?(
+            ClassWithMethodThatAcceptsUntrackedArguments,
+            :describe_thing
+          )
         end.to change { CruftTracker::Method.count }.by(1)
 
         ClassWithMethodThatAcceptsUntrackedArguments.new.describe_thing(
@@ -393,9 +437,7 @@ RSpec.describe(CruftTracker) do
         CruftTracker.is_this_method_used?(
           ClassWithMethodThatAcceptsTrackedArguments,
           :do_something,
-          track_arguments: ->(args) {
-            args.last.keys.sort
-          }
+          track_arguments: ->(args) { args.last.keys.sort }
         )
 
         example = ClassWithMethodThatAcceptsTrackedArguments.new
@@ -441,9 +483,7 @@ RSpec.describe(CruftTracker) do
         CruftTracker.is_this_method_used?(
           ClassWithMethodThatAcceptsTrackedArguments,
           :do_something,
-          track_arguments: ->(args) {
-            args.last.keys.sort
-          }
+          track_arguments: ->(args) { args.last.keys.sort }
         )
         starting_pistol_has_been_fired = false
 
@@ -486,7 +526,10 @@ RSpec.describe(CruftTracker) do
               deleted_at: 1.day.ago
             )
 
-          CruftTracker.is_this_method_used?(ClassWithTaggedInstanceMethod, :some_instance_method)
+          CruftTracker.is_this_method_used?(
+            ClassWithTaggedInstanceMethod,
+            :some_instance_method
+          )
 
           expect(method.reload.deleted_at).to be_nil
         end
@@ -496,7 +539,9 @@ RSpec.describe(CruftTracker) do
 
   describe '#are_any_of_these_methods_used?' do
     it 'tracks all class and instance methods belonging directly to a class' do
-      CruftTracker.are_any_of_these_methods_being_used?(ClassThatIsTrackingAllMethods)
+      CruftTracker.are_any_of_these_methods_being_used?(
+        ClassThatIsTrackingAllMethods
+      )
 
       ClassThatIsTrackingAllMethods.do_the_sneaky_thing
       ClassThatIsTrackingAllMethods.do_it
@@ -521,8 +566,9 @@ RSpec.describe(CruftTracker) do
       )
       expect(CruftTracker::Method.find_by(name: 'do_it').invocations).to eq(1)
       expect(
-        CruftTracker::Method.find_by(name: 'super_private_class_method')
-          .invocations
+        CruftTracker::Method.find_by(
+          name: 'super_private_class_method'
+        ).invocations
       ).to eq(1)
       expect(
         CruftTracker::Method.find_by(name: 'some_method').invocations
@@ -534,12 +580,14 @@ RSpec.describe(CruftTracker) do
         CruftTracker::Method.find_by(name: 'describe_thing').invocations
       ).to eq(0)
       expect(
-        CruftTracker::Method.find_by(name: 'kick_off_the_thing_to_do_twice')
-          .invocations
+        CruftTracker::Method.find_by(
+          name: 'kick_off_the_thing_to_do_twice'
+        ).invocations
       ).to eq(1)
       expect(
-        CruftTracker::Method.find_by(name: 'kick_off_the_thing_to_do')
-          .invocations
+        CruftTracker::Method.find_by(
+          name: 'kick_off_the_thing_to_do'
+        ).invocations
       ).to eq(2)
       expect(
         CruftTracker::Method.find_by(name: 'do_the_thing').invocations
@@ -566,7 +614,9 @@ RSpec.describe(CruftTracker) do
     end
 
     it 'tracks invocations of all methods on a module' do
-      CruftTracker.are_any_of_these_methods_being_used?(ModuleThatIsTrackingAllMethods)
+      CruftTracker.are_any_of_these_methods_being_used?(
+        ModuleThatIsTrackingAllMethods
+      )
 
       ModuleThatIsTrackingAllMethods.some_module_method
       ModuleThatIsTrackingAllMethods.be_sneaky
@@ -580,8 +630,9 @@ RSpec.describe(CruftTracker) do
         1
       )
       expect(
-        CruftTracker::Method.find_by(name: 'do_something_super_privately')
-          .invocations
+        CruftTracker::Method.find_by(
+          name: 'do_something_super_privately'
+        ).invocations
       ).to eq(1)
       expect(
         CruftTracker::Method.find_by(name: 'super_private_method').invocations


### PR DESCRIPTION
Subject say it all. This PR applies Prettier to all Ruby code. The. README has been updated to include instructions on how to do this. 

You can run it in docker with `bundle exec rbprettier --write '**/*.rb'`.