### PR TITLE
Stop catching ActiveRecord::RecordNotUnique

### DIFF
--- a/app/services/cruft_tracker/record_arguments.rb
+++ b/app/services/cruft_tracker/record_arguments.rb
@@ -24,20 +24,21 @@ module CruftTracker
     def arguments_record
       @arguments_record ||=
         begin
-          return find_existing_arguments_record if max_records_reached?
+          arguments_record = CruftTracker::Argument.find_by(
+            method: method,
+            arguments_hash: arguments_hash
+          )
+
+          if arguments_record.present? || max_records_reached?
+            return arguments_record
+          end
 
           CruftTracker::Argument.create(
             method: method,
             arguments_hash: arguments_hash,
             arguments: transformed_arguments
           )
-        rescue ActiveRecord::RecordNotUnique
-          find_existing_arguments_record
         end
-    end
-
-    def find_existing_arguments_record
-      CruftTracker::Argument.find_by(arguments_hash: arguments_hash)
     end
 
     def arguments_hash

--- a/app/services/cruft_tracker/record_backtrace.rb
+++ b/app/services/cruft_tracker/record_backtrace.rb
@@ -22,20 +22,21 @@ module CruftTracker
     def backtrace_record
       @backtrace_record ||=
         begin
-          return find_existing_backtrace_record if max_records_reached?
+          backtrace_record = CruftTracker::Backtrace.find_by(
+            traceable: method,
+            trace_hash: backtrace_hash
+          )
+
+          if backtrace_record.present? || max_records_reached?
+            return backtrace_record
+          end
 
           CruftTracker::Backtrace.create(
             traceable: method,
             trace_hash: backtrace_hash,
             trace: filtered_backtrace
           )
-        rescue ActiveRecord::RecordNotUnique
-          find_existing_backtrace_record
         end
-    end
-
-    def find_existing_backtrace_record
-      CruftTracker::Backtrace.find_by(trace_hash: backtrace_hash)
     end
 
     def backtrace_hash

--- a/app/services/cruft_tracker/record_render_metadata.rb
+++ b/app/services/cruft_tracker/record_render_metadata.rb
@@ -25,20 +25,21 @@ module CruftTracker
     def render_metadata_record
       @render_metadata_record ||=
         begin
-          return find_existing_render_metadata_record if max_records_reached?
+          render_metadata_record = CruftTracker::RenderMetadata.find_by(
+            view_render: view_render,
+            metadata_hash: metadata_hash
+          )
+
+          if render_metadata_record.present? || max_records_reached?
+            return render_metadata_record
+          end
 
           CruftTracker::RenderMetadata.create(
             view_render: view_render,
             metadata_hash: metadata_hash,
             metadata: metadata
           )
-        rescue ActiveRecord::RecordNotUnique
-          find_existing_render_metadata_record
         end
-    end
-
-    def find_existing_render_metadata_record
-      CruftTracker::RenderMetadata.find_by(metadata_hash: metadata_hash)
     end
 
     def metadata_hash

--- a/app/services/cruft_tracker/record_view_render.rb
+++ b/app/services/cruft_tracker/record_view_render.rb
@@ -52,7 +52,14 @@ module CruftTracker
     def view_render_record
       @view_render_record ||=
         begin
-          return find_existing_view_render_record if max_records_reached?
+          view_render_record = CruftTracker::ViewRender.find_by(
+            view: view,
+            render_hash: render_hash
+          )
+
+          if view_render_record.present? || max_records_reached?
+            return view_render_record
+          end
 
           CruftTracker::ViewRender.create(
             view: view,
@@ -63,13 +70,7 @@ module CruftTracker
             http_method: http_method,
             render_stack: render_stack
           )
-        rescue ActiveRecord::RecordNotUnique
-          find_existing_view_render_record
         end
-    end
-
-    def find_existing_view_render_record
-      CruftTracker::ViewRender.find_by(render_hash: render_hash)
     end
 
     def render_hash

--- a/app/services/cruft_tracker/track_method.rb
+++ b/app/services/cruft_tracker/track_method.rb
@@ -77,17 +77,19 @@ module CruftTracker
     end
 
     def create_or_find_method_record
+      method_record = CruftTracker::Method.find_by(
+        owner: owner.name,
+        name: name,
+        method_type: method_type
+      )
+
+      return method_record if method_record.present?
+
       CruftTracker::Method.create(
         owner: owner.name,
         name: name,
         method_type: method_type,
         comment: comment
-      )
-    rescue ActiveRecord::RecordNotUnique
-      CruftTracker::Method.find_by(
-        owner: owner.name,
-        name: name,
-        method_type: method_type
       )
     end
 

--- a/app/services/cruft_tracker/track_view.rb
+++ b/app/services/cruft_tracker/track_view.rb
@@ -52,9 +52,11 @@ module CruftTracker
     end
 
     def create_or_find_view_record
+      view_record = CruftTracker::View.find_by(view: view)
+
+      return view_record if view_record.present?
+
       CruftTracker::View.create(view: view, comment: comment)
-    rescue ActiveRecord::RecordNotUnique
-      CruftTracker::View.find_by(view: view)
     end
   end
 end

--- a/lib/cruft_tracker/version.rb
+++ b/lib/cruft_tracker/version.rb
@@ -1,3 +1,3 @@
 module CruftTracker
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
To try to save a read before writing to the DB, I had been proactively
trying to run a `create` on the various cruft_tracker records. I'd then
catch any ActiveRecord::RecordNotUnique and create a record, since it
didn't already exist. This resulted in spamming RecordNotUnique errors
and really wasn't helpful anyhow. This commit just tries reading the
record first with find_by. If not found, the record is created.