### PR TITLE
Suppress more logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cruft_tracker (0.2.2)
+    cruft_tracker (0.2.4)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 

--- a/app/services/cruft_tracker/record_arguments.rb
+++ b/app/services/cruft_tracker/record_arguments.rb
@@ -9,9 +9,9 @@ module CruftTracker
     private
 
     def execute
-      return unless arguments_record.present?
-
       CruftTracker::LogSuppressor.suppress_logging do
+        return unless arguments_record.present?
+
         arguments_record.with_lock do
           arguments_record.reload
           arguments_record.update(occurrences: arguments_record.occurrences + 1)

--- a/app/services/cruft_tracker/record_backtrace.rb
+++ b/app/services/cruft_tracker/record_backtrace.rb
@@ -7,9 +7,9 @@ module CruftTracker
     private
 
     def execute
-      return unless backtrace_record.present?
-
       CruftTracker::LogSuppressor.suppress_logging do
+        return unless backtrace_record.present?
+        
         backtrace_record.with_lock do
           backtrace_record.reload
           backtrace_record.update(occurrences: backtrace_record.occurrences + 1)

--- a/app/services/cruft_tracker/record_render_metadata.rb
+++ b/app/services/cruft_tracker/record_render_metadata.rb
@@ -10,9 +10,10 @@ module CruftTracker
 
     def execute
       return unless metadata.present?
-      return unless render_metadata_record.present?
 
       CruftTracker::LogSuppressor.suppress_logging do
+        return unless render_metadata_record.present?
+        
         render_metadata_record.with_lock do
           render_metadata_record.reload
           render_metadata_record.update(

--- a/app/services/cruft_tracker/record_view_render.rb
+++ b/app/services/cruft_tracker/record_view_render.rb
@@ -20,9 +20,9 @@ module CruftTracker
     private
 
     def execute
-      return unless view_render_record.present?
-
       CruftTracker::LogSuppressor.suppress_logging do
+        return unless view_render_record.present?
+
         view.with_lock do
           view.reload
           view.update(renders: view.renders + 1)

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cruft_tracker (0.2.2)
+    cruft_tracker (0.2.4)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cruft_tracker (0.2.2)
+    cruft_tracker (0.2.4)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cruft_tracker (0.2.2)
+    cruft_tracker (0.2.4)
       active_interaction (~> 4.1)
       rails (>= 5.2)
 

--- a/lib/cruft_tracker/version.rb
+++ b/lib/cruft_tracker/version.rb
@@ -1,3 +1,3 @@
 module CruftTracker
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end


### PR DESCRIPTION
I recently added some early return logic in some services that should
have been wrapped in the log suppressor. This commit wraps these bits.